### PR TITLE
fix: set sort options because

### DIFF
--- a/lib/services/tmdb_list_service.dart
+++ b/lib/services/tmdb_list_service.dart
@@ -270,6 +270,8 @@ class TmdbListService extends TmdbBaseService with ChangeNotifier {
           listName: listNameVal,
           offset: i,
           limit: batchSize,
+          sortOption: SortOption.addedOrder,
+          sortAscending: true,
         );
 
         final updated = await Future.wait(


### PR DESCRIPTION
as titles were localized and renamed, they changed positions in the alphabetically sorted list, causing the update loop to skip some and repeat others.